### PR TITLE
Add affinity group support for keeping VMs together during migrations

### DIFF
--- a/collector_api.py
+++ b/collector_api.py
@@ -249,18 +249,20 @@ class ProxmoxAPICollector:
             return []
 
     def parse_tags(self, tags_str: str) -> Dict:
-        """Parse tags and extract ignore/exclude rules"""
+        """Parse tags and extract ignore/exclude/affinity rules"""
         if not tags_str:
-            return {"has_ignore": False, "exclude_groups": [], "all_tags": []}
+            return {"has_ignore": False, "exclude_groups": [], "affinity_groups": [], "all_tags": []}
 
         tags = [t.strip() for t in tags_str.replace(";", " ").split()]
         has_ignore = "ignore" in tags
         exclude_groups = [t for t in tags if t.startswith("exclude_")]
+        affinity_groups = [t for t in tags if t.startswith("affinity_")]
         has_bindmount_tag = "has-bindmount" in tags
 
         return {
             "has_ignore": has_ignore,
             "exclude_groups": exclude_groups,
+            "affinity_groups": affinity_groups,
             "has_bindmount": has_bindmount_tag,
             "all_tags": tags
         }

--- a/config.example.json
+++ b/config.example.json
@@ -72,6 +72,7 @@
       "respect_ignore_tags": true,
       "respect_exclude_tags": true,
       "respect_exclude_affinity": true,
+      "respect_affinity_rules": true,
       "require_auto_migrate_ok_tag": false
     },
     "safety_checks": {


### PR DESCRIPTION
## Summary
This PR introduces affinity group functionality that allows VMs/containers to be tagged with `affinity_*` labels to keep them together on the same node. When a VM with an affinity tag is migrated, all other VMs sharing the same affinity tag are automatically migrated to the same target node as companion migrations.

## Key Changes

### Backend (app.py & automigrate.py)
- **Affinity Rules Engine**: Added comprehensive affinity group processing in `generate_recommendations()` that:
  - Identifies VMs with `affinity_*` tags
  - Generates companion migration recommendations for group members
  - Validates storage compatibility and anti-affinity conflicts for companions
  - Tracks affinity leaders and their companions in recommendation metadata
  
- **New API Endpoint** (`/api/affinity-groups`): Returns all affinity groups with member details and violation detection (groups split across multiple nodes)

- **automigrate.py Enhancements**:
  - Added `_extract_affinity_groups()` helper function
  - Implemented `get_affinity_companions()` to find group members needing migration
  - Integrated companion migration execution in the automation loop with proper logging and history tracking
  - Affinity companions inherit the leader's confidence score and get marked with affinity metadata

- **Tag Parsing**: Updated `collector_api.py` to extract and parse `affinity_*` tags alongside existing ignore/exclude tags

### Frontend (src/app.jsx)
- **Affinity Violation Detection**: Added detection for affinity groups split across multiple nodes in the violations checker
- **UI Components**:
  - New "Affinity Groups" card in dashboard showing count of VMs with affinity tags
  - Visual badges for affinity group leaders and companions in recommendations list
  - Affinity tag display with purple styling in guest table
  - Quick-add button for `affinity_*` tags in tag management
  - Updated tag sorting to include affinity group counts

- **Configuration UI**: Added toggle for `respect_affinity_rules` in automation settings with clear explanation

### Configuration
- Added `respect_affinity_rules` setting to `config.example.json` (defaults to `true`)

## Implementation Details

- **Companion Selection**: When a VM is recommended for migration, the system finds all other VMs sharing any of its affinity tags and generates recommendations for them to move to the same target node
- **Validation**: Companions undergo the same validation checks as primary recommendations (storage compatibility, anti-affinity conflicts, migration eligibility)
- **Metadata Tracking**: Recommendations include `affinity_group`, `affinity_leader_vmid`, and `affinity_companions` fields for UI display and audit trails
- **Graceful Degradation**: If a companion can't be migrated (due to conflicts or restrictions), the primary migration still proceeds
- **History Recording**: Companion migrations are recorded with affinity metadata for audit and reporting purposes

## Example Usage
Tag VMs with `affinity_webstack` to keep them together. When one is migrated, all others in the group automatically follow to the same node, maintaining application locality and reducing latency.

https://claude.ai/code/session_01RrzCPdLskW9eUrXXwVvVxt