### PR TITLE
fix(automation): allow editing Distribution Balancing number inputs on mobile

### DIFF
--- a/src/components/AutomationPage.jsx
+++ b/src/components/AutomationPage.jsx
@@ -1290,13 +1290,26 @@ export default function AutomationPage(props) {
                   type="number"
                   min="1"
                   max="10"
-                  value={config.distribution_balancing?.guest_count_threshold || 2}
+                  value={config.distribution_balancing?.guest_count_threshold ?? 2}
                   onChange={(e) => {
+                    const val = e.target.value;
+                    const numVal = val === '' ? '' : parseInt(val);
                     const newConfig = { ...config };
                     if (!newConfig.distribution_balancing) newConfig.distribution_balancing = {};
-                    newConfig.distribution_balancing.guest_count_threshold = parseInt(e.target.value);
+                    newConfig.distribution_balancing.guest_count_threshold = numVal;
                     setConfig(newConfig);
-                    saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    if (val !== '' && !isNaN(numVal)) {
+                      saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    }
+                  }}
+                  onBlur={(e) => {
+                    if (e.target.value === '') {
+                      const newConfig = { ...config };
+                      if (!newConfig.distribution_balancing) newConfig.distribution_balancing = {};
+                      newConfig.distribution_balancing.guest_count_threshold = 2;
+                      setConfig(newConfig);
+                      saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    }
                   }}
                   className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                 />
@@ -1314,13 +1327,26 @@ export default function AutomationPage(props) {
                   type="number"
                   min="0"
                   max="32"
-                  value={config.distribution_balancing?.max_cpu_cores || 2}
+                  value={config.distribution_balancing?.max_cpu_cores ?? 2}
                   onChange={(e) => {
+                    const val = e.target.value;
+                    const numVal = val === '' ? '' : parseInt(val);
                     const newConfig = { ...config };
                     if (!newConfig.distribution_balancing) newConfig.distribution_balancing = {};
-                    newConfig.distribution_balancing.max_cpu_cores = parseInt(e.target.value);
+                    newConfig.distribution_balancing.max_cpu_cores = numVal;
                     setConfig(newConfig);
-                    saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    if (val !== '' && !isNaN(numVal)) {
+                      saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    }
+                  }}
+                  onBlur={(e) => {
+                    if (e.target.value === '') {
+                      const newConfig = { ...config };
+                      if (!newConfig.distribution_balancing) newConfig.distribution_balancing = {};
+                      newConfig.distribution_balancing.max_cpu_cores = 2;
+                      setConfig(newConfig);
+                      saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    }
                   }}
                   className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                 />
@@ -1338,13 +1364,26 @@ export default function AutomationPage(props) {
                   type="number"
                   min="0"
                   max="256"
-                  value={config.distribution_balancing?.max_memory_gb || 4}
+                  value={config.distribution_balancing?.max_memory_gb ?? 4}
                   onChange={(e) => {
+                    const val = e.target.value;
+                    const numVal = val === '' ? '' : parseInt(val);
                     const newConfig = { ...config };
                     if (!newConfig.distribution_balancing) newConfig.distribution_balancing = {};
-                    newConfig.distribution_balancing.max_memory_gb = parseInt(e.target.value);
+                    newConfig.distribution_balancing.max_memory_gb = numVal;
                     setConfig(newConfig);
-                    saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    if (val !== '' && !isNaN(numVal)) {
+                      saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    }
+                  }}
+                  onBlur={(e) => {
+                    if (e.target.value === '') {
+                      const newConfig = { ...config };
+                      if (!newConfig.distribution_balancing) newConfig.distribution_balancing = {};
+                      newConfig.distribution_balancing.max_memory_gb = 4;
+                      setConfig(newConfig);
+                      saveAutomationConfig({ distribution_balancing: { ...newConfig.distribution_balancing } });
+                    }
                   }}
                   className="w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white"
                 />


### PR DESCRIPTION
On mobile, clearing a number input field before typing a new value caused
parseInt("") to return NaN, which the || default fallback immediately
reset to the default value, making the field uneditable.

Changes:
- Replace || with ?? for value props to allow setting 0 (no limit)
- Handle empty input during editing without snapping back to default
- Only save to backend when input contains a valid number
- Restore defaults on blur if field is left empty

https://claude.ai/code/session_01UqAWFYeEW23EoBqzfs6AF3