### PR TITLE
fix(automation): save distribution balancing config at root level

### DIFF
--- a/proxbalance/routes/automation.py
+++ b/proxbalance/routes/automation.py
@@ -678,9 +678,18 @@ def automigrate_config():
             if 'automated_migrations' not in config:
                 config['automated_migrations'] = {}
 
+            # Keys that belong at the root config level, not under automated_migrations
+            root_level_keys = {'distribution_balancing'}
+
             # Update configuration (deep merge)
             for key, value in updates.items():
-                if isinstance(value, dict) and key in config['automated_migrations']:
+                if key in root_level_keys:
+                    # Save root-level keys at the top level of config
+                    if isinstance(value, dict) and key in config:
+                        config[key].update(value)
+                    else:
+                        config[key] = value
+                elif isinstance(value, dict) and key in config['automated_migrations']:
                     config['automated_migrations'][key].update(value)
                 else:
                     config['automated_migrations'][key] = value


### PR DESCRIPTION
The POST handler for /api/automigrate/config was storing all updates
under config['automated_migrations'], but distribution_balancing is a
root-level config key. This caused values to be saved to the wrong
location and revert on page reload, since the backend reads from
config.get('distribution_balancing', {}).

https://claude.ai/code/session_01Q2oBh6x4WVzMFQEWx98EGH