### PR TITLE
fix(dashboard): prevent bottom nav from overlapping cluster map modals on mobile

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -8981,7 +8981,7 @@ const ProxBalanceLogo = ({ size = 32 }) => (
 
                 {/* Node Details Modal (from Cluster Map click) */}
                 {selectedNode && (
-                  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50 sm:p-4" onClick={() => setSelectedNode(null)}>
+                  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-[60] sm:p-4" onClick={() => setSelectedNode(null)}>
                     <div className="bg-white dark:bg-gray-800 rounded-t-xl sm:rounded-lg shadow-xl max-w-2xl w-full max-h-[85vh] sm:max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
                       {/* Modal Header - sticky so close button is always reachable */}
                       <div className="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700 shrink-0">
@@ -9360,7 +9360,7 @@ const ProxBalanceLogo = ({ size = 32 }) => (
 
                 {/* Guest Details Modal (from Cluster Map click) */}
                 {selectedGuestDetails && (
-                  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50 sm:p-4" onClick={() => setSelectedGuestDetails(null)}>
+                  <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-[60] sm:p-4" onClick={() => setSelectedGuestDetails(null)}>
                     <div className="bg-white dark:bg-gray-800 rounded-t-xl sm:rounded-lg shadow-xl max-w-3xl w-full max-h-[85vh] sm:max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
                       {/* Modal Header */}
                       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700 shrink-0">

--- a/src/components/DashboardPage.jsx
+++ b/src/components/DashboardPage.jsx
@@ -2459,7 +2459,7 @@ export default function DashboardPage({
 
         {/* Node Details Modal (from Cluster Map click) */}
         {selectedNode && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50 sm:p-4" onClick={() => setSelectedNode(null)}>
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-[60] sm:p-4" onClick={() => setSelectedNode(null)}>
             <div className="bg-white dark:bg-gray-800 rounded-t-xl sm:rounded-lg shadow-xl max-w-2xl w-full max-h-[85vh] sm:max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
               {/* Modal Header - sticky so close button is always reachable */}
               <div className="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700 shrink-0">
@@ -2839,7 +2839,7 @@ export default function DashboardPage({
 
         {/* Guest Details Modal (from Cluster Map click) */}
         {selectedGuestDetails && (
-          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-50 sm:p-4" onClick={() => setSelectedGuestDetails(null)}>
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-end sm:items-center justify-center z-[60] sm:p-4" onClick={() => setSelectedGuestDetails(null)}>
             <div className="bg-white dark:bg-gray-800 rounded-t-xl sm:rounded-lg shadow-xl max-w-3xl w-full max-h-[85vh] sm:max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
               {/* Modal Header */}
               <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700 shrink-0">


### PR DESCRIPTION
Raise z-index of node details and guest details modals from z-50 to z-[60]
so they render above the mobile bottom navigation bar (also z-50). The nav
bar appeared on top due to later DOM order, blocking the bottom portion of
the modal content including action buttons.

https://claude.ai/code/session_01X4k26oSCt33PQBACupTR31