### PR TITLE
feat(ui): add next run time display to automation status

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -7300,6 +7300,23 @@ const ProxBalanceLogo = ({ size = 32 }) => (
                             </span>
                           </div>
                         )}
+                        {automationStatus.next_check && (
+                          <div className="flex justify-between text-sm">
+                            <span className="text-gray-600 dark:text-gray-400">Next Run:</span>
+                            <span className="font-medium text-gray-900 dark:text-white">
+                              {(() => {
+                                let timestamp = automationStatus.next_check;
+                                if (timestamp && typeof timestamp === 'string') {
+                                  if (!timestamp.endsWith('Z') && !timestamp.includes('+')) {
+                                    timestamp += 'Z';
+                                  }
+                                  return new Date(timestamp).toLocaleString();
+                                }
+                                return 'Unknown';
+                              })()}
+                            </span>
+                          </div>
+                        )}
                       </div>
                     )}
 

--- a/src/components/DashboardPage.jsx
+++ b/src/components/DashboardPage.jsx
@@ -722,6 +722,23 @@ export default function DashboardPage({
                     </span>
                   </div>
                 )}
+                {automationStatus.next_check && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-600 dark:text-gray-400">Next Run:</span>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {(() => {
+                        let timestamp = automationStatus.next_check;
+                        if (timestamp && typeof timestamp === 'string') {
+                          if (!timestamp.endsWith('Z') && !timestamp.includes('+')) {
+                            timestamp += 'Z';
+                          }
+                          return new Date(timestamp).toLocaleString();
+                        }
+                        return 'Unknown';
+                      })()}
+                    </span>
+                  </div>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
Show the estimated next automation run time alongside the existing
last run timestamp in the dashboard automation widget.

https://claude.ai/code/session_018fkrbwH6tzSSMShfFFf16j