### PR TITLE
Add ability to dismiss testing mode without reverting branch

### DIFF
--- a/proxbalance/routes/system.py
+++ b/proxbalance/routes/system.py
@@ -365,6 +365,13 @@ def rollback_branch():
     status_code = 200 if result.get('success', False) else 400
     return jsonify(result), status_code
 
+@system_bp.route("/api/system/clear-testing-mode", methods=["POST"])
+def clear_testing_mode():
+    """Clear the previous branch tracking to exit testing mode"""
+    update_manager = current_app.config['update_manager']
+    result = update_manager.clear_testing_mode()
+    return jsonify(result), 200
+
 @system_bp.route("/api/system/restart-service", methods=["POST"])
 def restart_service():
     """Restart a ProxBalance service"""

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -408,6 +408,20 @@ export async function rollbackBranch() {
   }
 }
 
+export async function clearTestingMode() {
+  try {
+    const response = await fetch(`${API_BASE}/system/clear-testing-mode`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await response.json();
+    return result;
+  } catch (err) {
+    console.error('Error clearing testing mode:', err);
+    return { error: true, message: err.message };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Automation (AutoMigrate)
 // ---------------------------------------------------------------------------

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1386,6 +1386,21 @@ const ProxBalanceLogo = ({ size = 32 }) => (
             setRollingBack(false);
           };
 
+          const clearTestingMode = async () => {
+            try {
+              const response = await fetch(`${API_BASE}/system/clear-testing-mode`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' }
+              });
+              const result = await response.json();
+              if (result.success) {
+                await fetchSystemInfo();
+              }
+            } catch (err) {
+              setError(`Error clearing testing mode: ${err.message}`);
+            }
+          };
+
           const cancelMigration = async (vmid, targetNode) => {
             const key = `${vmid}-${targetNode}`;
             const migration = activeMigrations[key];
@@ -11156,13 +11171,23 @@ const ProxBalanceLogo = ({ size = 32 }) => (
                                   Testing a branch? Return to <span className="font-mono font-semibold">{systemInfo.previous_branch}</span>
                                 </span>
                               </div>
-                              <button
-                                onClick={rollbackBranch}
-                                disabled={rollingBack || switchingBranch || (systemInfo && systemInfo.update_in_progress)}
-                                className="px-3 py-1.5 bg-amber-600 text-white text-sm rounded hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                              >
-                                {rollingBack ? 'Switching...' : (systemInfo && systemInfo.update_in_progress ? 'Busy...' : 'Go Back')}
-                              </button>
+                              <div className="flex items-center gap-2">
+                                <button
+                                  onClick={clearTestingMode}
+                                  disabled={rollingBack || switchingBranch || (systemInfo && systemInfo.update_in_progress)}
+                                  className="px-3 py-1.5 text-amber-700 dark:text-amber-300 text-sm rounded border border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                                  title="Stay on current branch and dismiss this banner"
+                                >
+                                  Dismiss
+                                </button>
+                                <button
+                                  onClick={rollbackBranch}
+                                  disabled={rollingBack || switchingBranch || (systemInfo && systemInfo.update_in_progress)}
+                                  className="px-3 py-1.5 bg-amber-600 text-white text-sm rounded hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                  {rollingBack ? 'Switching...' : (systemInfo && systemInfo.update_in_progress ? 'Busy...' : 'Go Back')}
+                                </button>
+                              </div>
                             </div>
                           </div>
                         )}
@@ -11916,9 +11941,13 @@ const ProxBalanceLogo = ({ size = 32 }) => (
                           title="Click to manage branches"
                         >{systemInfo.branch}</button></span>
                         {systemInfo.previous_branch && systemInfo.previous_branch !== systemInfo.branch && (
-                          <span className="px-1.5 py-0.5 text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 rounded" title={`Return to ${systemInfo.previous_branch}`}>
-                            testing
-                          </span>
+                          <button
+                            onClick={clearTestingMode}
+                            className="px-1.5 py-0.5 text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 rounded hover:bg-amber-200 dark:hover:bg-amber-800/50 cursor-pointer"
+                            title={`Click to dismiss — previously on ${systemInfo.previous_branch}`}
+                          >
+                            testing &times;
+                          </button>
                         )}
                         <span className="text-gray-300 dark:text-gray-700">|</span>
                         <span>Commit: <span className="font-mono text-gray-600 dark:text-gray-400">{systemInfo.commit}</span></span>

--- a/src/components/DashboardPage.jsx
+++ b/src/components/DashboardPage.jsx
@@ -29,7 +29,7 @@ export default function DashboardPage({
   updateResult, setUpdateResult, updateError, handleUpdate,
   // Branch management
   showBranchModal, setShowBranchModal, loadingBranches, availableBranches, branchPreview, setBranchPreview,
-  loadingPreview, switchingBranch, rollingBack, fetchBranches, switchBranch, rollbackBranch, fetchBranchPreview,
+  loadingPreview, switchingBranch, rollingBack, fetchBranches, switchBranch, rollbackBranch, clearTestingMode, fetchBranchPreview,
   // Automation
   automationStatus, automationConfig, fetchAutomationStatus, runAutomationNow, runningAutomation,
   runNowMessage, setRunNowMessage, runHistory, expandedRun, setExpandedRun,
@@ -4609,13 +4609,23 @@ export default function DashboardPage({
                           Testing a branch? Return to <span className="font-mono font-semibold">{systemInfo.previous_branch}</span>
                         </span>
                       </div>
-                      <button
-                        onClick={rollbackBranch}
-                        disabled={rollingBack || switchingBranch || (systemInfo && systemInfo.update_in_progress)}
-                        className="px-3 py-1.5 bg-amber-600 text-white text-sm rounded hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        {rollingBack ? 'Switching...' : (systemInfo && systemInfo.update_in_progress ? 'Busy...' : 'Go Back')}
-                      </button>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={clearTestingMode}
+                          disabled={rollingBack || switchingBranch || (systemInfo && systemInfo.update_in_progress)}
+                          className="px-3 py-1.5 text-amber-700 dark:text-amber-300 text-sm rounded border border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                          title="Stay on current branch and dismiss this banner"
+                        >
+                          Dismiss
+                        </button>
+                        <button
+                          onClick={rollbackBranch}
+                          disabled={rollingBack || switchingBranch || (systemInfo && systemInfo.update_in_progress)}
+                          className="px-3 py-1.5 bg-amber-600 text-white text-sm rounded hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {rollingBack ? 'Switching...' : (systemInfo && systemInfo.update_in_progress ? 'Busy...' : 'Go Back')}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 )}
@@ -5369,9 +5379,13 @@ export default function DashboardPage({
                   title="Click to manage branches"
                 >{systemInfo.branch}</button></span>
                 {systemInfo.previous_branch && systemInfo.previous_branch !== systemInfo.branch && (
-                  <span className="px-1.5 py-0.5 text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 rounded" title={`Return to ${systemInfo.previous_branch}`}>
-                    testing
-                  </span>
+                  <button
+                    onClick={clearTestingMode}
+                    className="px-1.5 py-0.5 text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 rounded hover:bg-amber-200 dark:hover:bg-amber-800/50 cursor-pointer"
+                    title={`Click to dismiss — previously on ${systemInfo.previous_branch}`}
+                  >
+                    testing &times;
+                  </button>
                 )}
                 <span className="text-gray-300 dark:text-gray-700">|</span>
                 <span>Commit: <span className="font-mono text-gray-600 dark:text-gray-400">{systemInfo.commit}</span></span>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1298,6 +1298,21 @@ const { useState, useEffect, useMemo, useCallback, useRef } = React;
             setRollingBack(false);
           };
 
+          const clearTestingMode = async () => {
+            try {
+              const response = await fetch(`${API_BASE}/system/clear-testing-mode`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' }
+              });
+              const result = await response.json();
+              if (result.success) {
+                await fetchSystemInfo();
+              }
+            } catch (err) {
+              setError(`Error clearing testing mode: ${err.message}`);
+            }
+          };
+
           const cancelMigration = async (vmid, targetNode) => {
             const key = `${vmid}-${targetNode}`;
             const migration = activeMigrations[key];
@@ -2354,7 +2369,7 @@ const { useState, useEffect, useMemo, useCallback, useRef } = React;
             loadingPreview={loadingPreview} switchingBranch={switchingBranch}
             rollingBack={rollingBack}
             fetchBranches={fetchBranches} switchBranch={switchBranch}
-            rollbackBranch={rollbackBranch} fetchBranchPreview={fetchBranchPreview}
+            rollbackBranch={rollbackBranch} clearTestingMode={clearTestingMode} fetchBranchPreview={fetchBranchPreview}
             automationStatus={automationStatus} automationConfig={automationConfig}
             fetchAutomationStatus={fetchAutomationStatus}
             runAutomationNow={runAutomationNow} runningAutomation={runningAutomation}

--- a/update_manager.py
+++ b/update_manager.py
@@ -321,6 +321,14 @@ class UpdateManager:
         except FileNotFoundError:
             pass
 
+    def clear_testing_mode(self) -> Dict:
+        """Clear the previous branch tracking to exit testing mode."""
+        previous = self._load_previous_branch()
+        if not previous:
+            return {'success': True, 'message': 'Not in testing mode'}
+        self._clear_previous_branch()
+        return {'success': True, 'message': f'Cleared testing mode (was tracking {previous})'}
+
     # ------------------------------------------------------------------
     # Operation lock (prevents concurrent updates/switches)
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds a new "Dismiss" feature that allows users to clear the testing mode indicator and exit branch testing without reverting to the previous branch. Previously, users had only two options when testing a branch: stay on the test branch with the testing indicator, or revert completely to the previous branch.

## Key Changes
- **Backend**: Added `clear_testing_mode()` endpoint in `proxbalance/routes/system.py` that clears previous branch tracking via the update manager
- **Update Manager**: Implemented `clear_testing_mode()` method in `update_manager.py` to safely clear testing mode state
- **API Client**: Added `clearTestingMode()` function in `src/api/client.js` for frontend API calls
- **UI Components**: 
  - Added "Dismiss" button alongside "Go Back" button in the testing mode banner (both `src/app.jsx` and `src/components/DashboardPage.jsx`)
  - Converted the "testing" badge in the system info header to a clickable button with an × symbol for quick dismissal
  - Updated styling to match the amber warning theme with appropriate hover states
- **State Management**: Passed `clearTestingMode` function through component props in `src/index.jsx` and `src/components/DashboardPage.jsx`

## Implementation Details
- The "Dismiss" action clears the `previous_branch` tracking without changing the current branch
- Users can dismiss the testing indicator from two locations: the prominent banner and the compact badge in the header
- After dismissing, `fetchSystemInfo()` is called to refresh the UI and remove the testing mode indicators
- The feature respects the same disabled state as the "Go Back" button (during migrations or updates)
- Maintains backward compatibility with existing branch rollback functionality

https://claude.ai/code/session_01FmtHH6W65q1u5NdyCNaFZQ