### PR TITLE
Add Respect Affinity Rules toggle to Safety Rules Section

### DIFF
--- a/src/components/automation/SafetyRulesSection.jsx
+++ b/src/components/automation/SafetyRulesSection.jsx
@@ -383,6 +383,25 @@ export default function SafetyRulesSection({ automationConfig, saveAutomationCon
                 </div>
               </div>
 
+              {/* Respect Pro-Affinity */}
+              <div className="bg-gray-50 dark:bg-gray-700 rounded-lg">
+                <div className="flex items-center justify-between p-4">
+                  <div>
+                    <div className="font-semibold text-gray-900 dark:text-white">Respect Affinity (affinity_* tags)</div>
+                    <div className="text-sm text-gray-600 dark:text-gray-400">Keeps VMs with the same affinity tag together on the same node. Companion VMs follow when one is migrated.</div>
+                  </div>
+                  <label className="relative inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={automationConfig.rules?.respect_affinity_rules !== false}
+                      onChange={(e) => saveAutomationConfig({ rules: { ...automationConfig.rules, respect_affinity_rules: e.target.checked } })}
+                      className="sr-only peer"
+                    />
+                    <div className="w-11 h-6 bg-gray-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-green-600"></div>
+                  </label>
+                </div>
+              </div>
+
               {/* Respect Anti-Affinity */}
               <div className="bg-gray-50 dark:bg-gray-700 rounded-lg">
                 <div className="flex items-center justify-between p-4">


### PR DESCRIPTION
## Summary
Added a new "Respect Affinity" toggle control to the Safety Rules Section that allows users to enable/disable affinity rule enforcement for VM placement and migration.

## Key Changes
- Added a new toggle switch for `respect_affinity_rules` configuration option
- Positioned before the existing "Respect Anti-Affinity" section for logical grouping
- Includes descriptive label explaining that affinity rules keep VMs with the same affinity tag together on the same node, with companion VMs following during migration
- Implements full dark mode support with appropriate color classes
- Follows existing UI patterns and styling conventions used in the component

## Implementation Details
- The toggle defaults to enabled (`respect_affinity_rules !== false`)
- Updates the automation config via the existing `saveAutomationConfig` callback
- Uses the same toggle component styling as other rules in the section
- Includes accessibility features (sr-only input, focus rings, proper contrast)

https://claude.ai/code/session_01EUNW4RErXCbbN1rnHsaggi