### PR TITLE
Move migration flow visualization to recommendations section

### DIFF
--- a/src/components/DashboardPage.jsx
+++ b/src/components/DashboardPage.jsx
@@ -213,7 +213,6 @@ export default function DashboardPage({
           setShowPoweredOffGuests={setShowPoweredOffGuests}
           clusterMapViewMode={clusterMapViewMode}
           setClusterMapViewMode={setClusterMapViewMode}
-          recommendations={recommendations}
           maintenanceNodes={maintenanceNodes}
           setSelectedNode={setSelectedNode}
           setSelectedGuestDetails={setSelectedGuestDetails}

--- a/src/components/dashboard/ClusterMap.jsx
+++ b/src/components/dashboard/ClusterMap.jsx
@@ -1,6 +1,6 @@
 import {
   Server, ChevronDown, ChevronUp, Cpu, MemoryStick, Database, Zap, Globe,
-  MoveRight, ArrowRight, RefreshCw, CheckCircle, Folder
+  RefreshCw, CheckCircle, Folder
 } from '../Icons.jsx';
 
 export default function ClusterMap({
@@ -11,7 +11,6 @@ export default function ClusterMap({
   setShowPoweredOffGuests,
   clusterMapViewMode,
   setClusterMapViewMode,
-  recommendations,
   maintenanceNodes,
   setSelectedNode,
   setSelectedGuestDetails,
@@ -126,48 +125,6 @@ export default function ClusterMap({
 
       {!collapsedSections.clusterMap && (
         <div className="relative" style={{minHeight: '400px'}}>
-          {/* C2: Migration Flow Arrows — visual summary of proposed migrations */}
-          {recommendations.length > 0 && (
-            <div className="mb-4 p-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
-              <div className="flex items-center gap-2 mb-2">
-                <MoveRight size={14} className="text-blue-600 dark:text-blue-400" />
-                <span className="text-xs font-medium text-blue-700 dark:text-blue-300">Proposed Migration Flows</span>
-                <span className="text-[10px] text-blue-500 dark:text-blue-400">({recommendations.length} migration{recommendations.length !== 1 ? 's' : ''})</span>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {(() => {
-                  // Group migrations by source->target pairs
-                  const flows = {};
-                  recommendations.forEach(rec => {
-                    const flowKey = `${rec.source_node}→${rec.target_node}`;
-                    if (!flows[flowKey]) flows[flowKey] = { source: rec.source_node, target: rec.target_node, guests: [], totalImprovement: 0 };
-                    flows[flowKey].guests.push({ vmid: rec.vmid, name: rec.name, type: rec.type });
-                    flows[flowKey].totalImprovement += rec.score_improvement || 0;
-                  });
-                  return Object.values(flows).map((flow, idx) => {
-                    const confColor = flow.totalImprovement > 40 ? 'bg-green-500' : flow.totalImprovement > 20 ? 'bg-yellow-500' : 'bg-gray-400';
-                    return (
-                      <div key={idx} className="flex items-center gap-1.5 px-2 py-1.5 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 text-[11px] group relative" title={flow.guests.map(g => `${g.type} ${g.vmid} (${g.name})`).join(', ')}>
-                        <span className="font-semibold text-gray-700 dark:text-gray-300">{flow.source}</span>
-                        <div className="flex items-center gap-0.5">
-                          <div className={`w-8 h-0.5 ${confColor} rounded`}></div>
-                          <ArrowRight size={10} className="text-gray-500 dark:text-gray-400 -ml-0.5" />
-                        </div>
-                        <span className="font-semibold text-gray-700 dark:text-gray-300">{flow.target}</span>
-                        <span className="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[9px] font-medium">{flow.guests.length}×</span>
-                        <div className="hidden group-hover:block absolute top-full left-0 mt-1 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2 min-w-[180px]">
-                          {flow.guests.map((g, i) => (
-                            <div key={i} className="text-[10px] text-gray-600 dark:text-gray-400 py-0.5">[{g.type} {g.vmid}] {g.name}</div>
-                          ))}
-                          <div className="text-[10px] text-green-600 dark:text-green-400 mt-1 pt-1 border-t border-gray-200 dark:border-gray-700">Total improvement: +{flow.totalImprovement.toFixed(0)} pts</div>
-                        </div>
-                      </div>
-                    );
-                  });
-                })()}
-              </div>
-            </div>
-          )}
           <div className="flex flex-wrap gap-4 sm:gap-8 justify-center items-start py-8">
             {Object.values(data.nodes).map(node => {
               const allNodeGuests = Object.values(data.guests || {}).filter(g => g.node === node.name);

--- a/src/components/dashboard/MigrationRecommendationsSection.jsx
+++ b/src/components/dashboard/MigrationRecommendationsSection.jsx
@@ -1,6 +1,6 @@
 import {
   Activity, RefreshCw, CheckCircle, ChevronDown, ChevronUp,
-  Download, ClipboardList, Info, Eye
+  Download, ClipboardList, Info, Eye, MoveRight, ArrowRight
 } from '../Icons.jsx';
 
 import { formatLocalTime } from '../../utils/formatters.js';
@@ -285,6 +285,48 @@ export default function MigrationRecommendationsSection({
               recSortDir={recSortDir}
               setRecSortDir={setRecSortDir}
             />
+          )}
+
+          {/* Proposed Migration Flows — visual summary of source→target pairs */}
+          {!loadingRecommendations && recommendations.length > 0 && (
+            <div className="mb-4 p-3 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+              <div className="flex items-center gap-2 mb-2">
+                <MoveRight size={14} className="text-blue-600 dark:text-blue-400" />
+                <span className="text-xs font-medium text-blue-700 dark:text-blue-300">Proposed Migration Flows</span>
+                <span className="text-[10px] text-blue-500 dark:text-blue-400">({recommendations.length} migration{recommendations.length !== 1 ? 's' : ''})</span>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {(() => {
+                  const flows = {};
+                  recommendations.forEach(rec => {
+                    const flowKey = `${rec.source_node}→${rec.target_node}`;
+                    if (!flows[flowKey]) flows[flowKey] = { source: rec.source_node, target: rec.target_node, guests: [], totalImprovement: 0 };
+                    flows[flowKey].guests.push({ vmid: rec.vmid, name: rec.name, type: rec.type });
+                    flows[flowKey].totalImprovement += rec.score_improvement || 0;
+                  });
+                  return Object.values(flows).map((flow, idx) => {
+                    const confColor = flow.totalImprovement > 40 ? 'bg-green-500' : flow.totalImprovement > 20 ? 'bg-yellow-500' : 'bg-gray-400';
+                    return (
+                      <div key={idx} className="flex items-center gap-1.5 px-2 py-1.5 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700 text-[11px] group relative" title={flow.guests.map(g => `${g.type} ${g.vmid} (${g.name})`).join(', ')}>
+                        <span className="font-semibold text-gray-700 dark:text-gray-300">{flow.source}</span>
+                        <div className="flex items-center gap-0.5">
+                          <div className={`w-8 h-0.5 ${confColor} rounded`}></div>
+                          <ArrowRight size={10} className="text-gray-500 dark:text-gray-400 -ml-0.5" />
+                        </div>
+                        <span className="font-semibold text-gray-700 dark:text-gray-300">{flow.target}</span>
+                        <span className="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-[9px] font-medium">{flow.guests.length}×</span>
+                        <div className="hidden group-hover:block absolute top-full left-0 mt-1 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2 min-w-[180px]">
+                          {flow.guests.map((g, i) => (
+                            <div key={i} className="text-[10px] text-gray-600 dark:text-gray-400 py-0.5">[{g.type} {g.vmid}] {g.name}</div>
+                          ))}
+                          <div className="text-[10px] text-green-600 dark:text-green-400 mt-1 pt-1 border-t border-gray-200 dark:border-gray-700">Total improvement: +{flow.totalImprovement.toFixed(0)} pts</div>
+                        </div>
+                      </div>
+                    );
+                  });
+                })()}
+              </div>
+            </div>
           )}
 
           {/* Main Content: Loading / Empty / Recommendation Cards */}


### PR DESCRIPTION
## Summary
Refactored the migration flow visualization component by relocating it from the ClusterMap component to the MigrationRecommendationsSection component. This improves component organization by keeping migration-related UI elements together in their logical section.

## Key Changes
- **Removed** the "Proposed Migration Flows" visualization from `ClusterMap.jsx`:
  - Removed `recommendations` prop from ClusterMap
  - Removed unused icon imports (`MoveRight`, `ArrowRight`)
  - Deleted the entire migration flows rendering block (48 lines)

- **Added** the "Proposed Migration Flows" visualization to `MigrationRecommendationsSection.jsx`:
  - Added `MoveRight` and `ArrowRight` icon imports
  - Implemented the same migration flow visualization logic with identical styling and functionality
  - Positioned the component above the main recommendation cards list
  - Added loading state check to prevent rendering during data fetch

- **Updated** `DashboardPage.jsx`:
  - Removed `recommendations` prop being passed to ClusterMap component

## Implementation Details
The migration flow visualization displays:
- Source → target node pairs grouped from individual migration recommendations
- Color-coded confidence indicators based on total improvement score
- Guest count badges and hover tooltips showing detailed migration information
- Responsive layout with dark mode support

The component maintains feature parity with the original implementation while being logically grouped with other migration recommendation UI elements.

https://claude.ai/code/session_01LQtNJnEzXHjunjrXbxAH9q