### PR TITLE
Add minimum CPU threshold for bursty guest classification

### DIFF
--- a/proxbalance/guest_profiles.py
+++ b/proxbalance/guest_profiles.py
@@ -154,7 +154,7 @@ def classify_guest_behavior(profile: Dict[str, Any]) -> Dict[str, Any]:
     data_points = len(cpu_avgs)
     confidence = "high" if data_points >= 48 else ("medium" if data_points >= 12 else "low")
 
-    if peak_mult > 2.0:
+    if peak_mult > 2.0 and mean_avg > 5:
         behavior = "bursty"
     elif abs(growth_per_day) > 2.0 and mean_avg > 5:
         behavior = "growing"

--- a/proxbalance/trend_analysis.py
+++ b/proxbalance/trend_analysis.py
@@ -41,6 +41,10 @@ STABILITY_GOOD = 0.20         # CV < 20% = stable
 STABILITY_MODERATE = 0.35     # CV < 35% = moderate
 # Above 35% = volatile
 
+# Minimum average CPU % for bursty classification — guests below this threshold
+# have negligible absolute impact even when their relative volatility (CV) is high
+BURSTY_MIN_CPU = 5.0
+
 
 # ---------------------------------------------------------------------------
 # Core statistical helpers
@@ -386,10 +390,11 @@ def analyze_guest_trends(
     cpu_rate = abs(cpu_trend.get("rate_per_day", 0))
     mem_rate = abs(mem_trend.get("rate_per_day", 0))
     cpu_stab = cpu_trend.get("stability_score", 50)
+    cpu_avg = cpu_trend.get("current_avg", 0)
 
     if cpu_trend["direction"] in ("sustained_increase", "rising") and cpu_rate > 1.0:
         behavior = "growing"
-    elif cpu_stab < 40:
+    elif cpu_stab < 40 and cpu_avg >= BURSTY_MIN_CPU:
         behavior = "bursty"
     elif cpu_stab >= 75:
         behavior = "steady"


### PR DESCRIPTION
## Summary
This PR refines the guest behavior classification logic to prevent guests with negligible absolute CPU usage from being classified as "bursty" based solely on high relative volatility. This improves the accuracy of resource behavior analysis by distinguishing between guests with genuinely problematic burst patterns versus those with low baseline usage that naturally exhibit high coefficient of variation.

## Key Changes
- **New constant `BURSTY_MIN_CPU`**: Introduced a 5% minimum average CPU threshold for bursty classification in `trend_analysis.py`
- **Updated bursty detection in `analyze_guest_trends()`**: Modified the stability-based bursty classification to additionally check that average CPU usage meets the minimum threshold (`cpu_avg >= BURSTY_MIN_CPU`)
- **Updated bursty detection in `classify_guest_behavior()`**: Added the same minimum CPU threshold check (`mean_avg > 5`) to the peak multiplier-based bursty classification logic

## Implementation Details
Both classification paths now enforce the minimum CPU threshold:
1. Stability-based path: `cpu_stab < 40 and cpu_avg >= BURSTY_MIN_CPU`
2. Peak multiplier-based path: `peak_mult > 2.0 and mean_avg > 5`

This ensures that guests with low absolute CPU consumption are not misclassified as bursty, even when their relative volatility is high. The threshold of 5% provides a reasonable cutoff for distinguishing between genuinely problematic burst patterns and statistical noise in low-usage guests.

https://claude.ai/code/session_01UeR1EMnWwvNQ1ZurQBHffz