### PR TITLE
Disable memory trend penalties and use immediate values for memory metrics

### DIFF
--- a/proxbalance/routes/recommendations.py
+++ b/proxbalance/routes/recommendations.py
@@ -619,10 +619,10 @@ def node_scores():
 
         if metrics.get("has_historical"):
             weighted_cpu = (immediate_cpu * weight_current) + (short_cpu * weight_24h) + (long_cpu * weight_7d)
-            weighted_mem = (immediate_mem * weight_current) + (short_mem * weight_24h) + (long_mem * weight_7d)
         else:
             weighted_cpu = immediate_cpu
-            weighted_mem = immediate_mem
+        # Memory uses current value — it's a step-function resource (see scoring.py).
+        weighted_mem = immediate_mem
 
         # Determine suitability based on score thresholds
         # Lower scores are better migration targets


### PR DESCRIPTION
## Summary
This PR fixes memory metric handling in the load balancing algorithm by disabling memory trend penalties and using only immediate (current) memory readings instead of time-weighted historical averages. This addresses a fundamental issue where memory trends in Proxmox reflect migration history rather than actual workload changes.

## Key Changes

- **Disabled memory trend penalties**: Set `mem_trend_rising_penalty` from 5 to 0 across all scoring functions. Memory "trends" in Proxmox are artifacts of VM migrations, not indicators of increasing workload demand.

- **Use immediate memory values only**: Replaced time-weighted memory calculations with direct current readings in:
  - `calculate_node_health_score()` 
  - `predict_post_migration_load()`
  - `calculate_target_node_score()`
  - `_check_cluster_convergence()`
  - `_weighted()` helper in recommendation analysis
  - `node_scores()` API endpoint

- **Updated memory trend reporting**: Changed memory trend evidence from "problem" to "info" type with lower weight, noting that rising memory trends indicate recent migrations rather than workload growth.

- **Added explanatory comments**: Documented why memory is treated as a step-function resource (fixed VM/CT allocations that only change on migration/start/stop) rather than a dynamic metric like CPU or IOWait.

## Implementation Details

Memory in Proxmox is fundamentally different from CPU/IOWait metrics:
- **CPU/IOWait**: Dynamic metrics that benefit from time-weighted smoothing to filter transient spikes
- **Memory**: Step-function allocations that only change when guests are migrated, started, or stopped

Blending current memory with historical averages creates "phantom values" — nodes receiving migrated VMs appear to have less memory than reality, while nodes losing VMs appear to have more. Using only the immediate reading accurately reflects the actual current state.

The memory trend penalty logic is now guarded by a check for `base_mem_trend_penalty > 0`, allowing it to be re-enabled in the future if needed, but disabled by default.

https://claude.ai/code/session_01HDzZ8fNrNQwBmAXvBWa79e