### PR TITLE
fix(automigrate): prevent migration ping-pong with memory floor gate …

### DIFF
--- a/proxbalance/scoring.py
+++ b/proxbalance/scoring.py
@@ -105,6 +105,11 @@ DEFAULT_PENALTY_CONFIG = {
     "maintenance_score_boost": 100,   # Extra score added to maintenance nodes for evacuation priority
     "iowait_score_boost": 30,        # Extra score added to IOWait-stressed nodes to trigger migrations
 
+    # Source memory migration floor: don't recommend migrating guests off a node
+    # when its memory is below this % (unless CPU or IOWait is also high).
+    # Prevents score-differential churn between nodes that are all healthy.
+    "source_mem_migration_floor": 65,
+
     # Time period weighting (for historical data)
     "weight_current": 0.5,            # Weight for current/immediate metrics (50%)
     "weight_24h": 0.3,                # Weight for 24-hour average metrics (30%)

--- a/proxbalance/settings_mapper.py
+++ b/proxbalance/settings_mapper.py
@@ -137,6 +137,12 @@ def map_simplified_to_penalty_config(settings: Dict[str, Any]) -> Dict[str, Any]
         cfg["min_score_improvement"] = profile["min_score_improvement"]
     cfg["cluster_convergence_threshold"] = profile["convergence_threshold"]
 
+    # --- Source memory migration floor ---
+    # Explicit override takes priority; otherwise keep the default (65%)
+    mem_floor = settings.get("source_mem_migration_floor")
+    if mem_floor is not None and isinstance(mem_floor, (int, float)):
+        cfg["source_mem_migration_floor"] = int(mem_floor)
+
     # --- Time period weights from trend_weight ---
     # trend_weight 0% → pure snapshot: current=0.9, 24h=0.1, 7d=0.0
     # trend_weight 50% → balanced:      current=0.5, 24h=0.3, 7d=0.2


### PR DESCRIPTION
…and escalating cooldowns

Three root causes of VM ping-pong between hosts were identified:
1. Score-differential churn: nodes at 55% memory generated "high memory" recommendations simply because other nodes were at 23%, even though 55% is well below the 70% threshold
2. Fixed cooldown periods allowed repeat movers to escape cooldown and get shuffled again within days
3. Cycle detection window (48h) was too narrow for multi-day patterns

Changes:
- Add source memory migration floor (65%): skip migration recommendations for guests on nodes with memory below this floor when CPU and IOWait are also healthy. Prevents churn between nodes that are all comfortable.
- Add exponential cooldown for repeat movers: VMs migrated multiple times within 7 days get progressively longer cooldowns (2x/4x/8x base), breaking ping-pong cycles that slip past cycle detection.
- Increase cycle detection window default from 48h to 72h.
- Use graduated severity language in reason text ("moderate"/"elevated"/ "high"/"critical") instead of always saying "high" regardless of value.
- Add source_mem_migration_floor to DEFAULT_PENALTY_CONFIG and settings mapper for UI configurability.

https://claude.ai/code/session_01VDZvCJkhdwvHNyAF89MwiL