### PR TITLE
fix(api,installer): fix AI provider import and add VLAN support

### DIFF
--- a/ai_provider.py
+++ b/ai_provider.py
@@ -604,6 +604,6 @@ def get_ai_provider() -> Optional[AIProvider]:
     Returns:
         AIProvider instance if configured, None otherwise
     """
-    from app import load_config
+    from proxbalance.config_manager import load_config
     config = load_config()
     return AIProviderFactory.create_provider(config)

--- a/install.sh
+++ b/install.sh
@@ -381,9 +381,19 @@ select_network() {
   read choice
   choice=${choice:-1}
 
+  # Optional VLAN tag
+  echo ""
+  echo -ne "${PROMPT_COLOR}${ARROW}${CL} VLAN tag ${DIM_COLOR}(leave blank for none)${CL}: "
+  read vlan_tag
+
+  if [ -n "$vlan_tag" ] && { [[ ! "$vlan_tag" =~ ^[1-9][0-9]{0,3}$ ]] || [ "$vlan_tag" -gt 4094 ]; }; then
+    msg_warn "Invalid VLAN tag (must be 1-4094), ignoring"
+    vlan_tag=""
+  fi
+
   case $choice in
     1)
-      NET_CONFIG="name=eth0,bridge=vmbr0,ip=dhcp"
+      NET_CONFIG="name=eth0,bridge=vmbr0,ip=dhcp${vlan_tag:+,tag=${vlan_tag}}"
       echo ""
       msg_ok "Network: ${VALUE_COLOR}DHCP (Automatic)${CL}"
       ;;
@@ -403,15 +413,18 @@ select_network() {
         return
       fi
 
-      NET_CONFIG="name=eth0,bridge=vmbr0,ip=${ip_addr}/${cidr},gw=${gateway}"
+      NET_CONFIG="name=eth0,bridge=vmbr0,ip=${ip_addr}/${cidr},gw=${gateway}${vlan_tag:+,tag=${vlan_tag}}"
       echo ""
       msg_ok "Static IP: ${VALUE_COLOR}${ip_addr}/${cidr}${CL} via ${VALUE_COLOR}${gateway}${CL}"
       ;;
     *)
       msg_error "Invalid selection"
       select_network
+      return
       ;;
   esac
+
+  [ -n "$vlan_tag" ] && msg_ok "VLAN tag: ${VALUE_COLOR}${vlan_tag}${CL}"
 }
 
 select_storage() {


### PR DESCRIPTION
## Summary
- **Fixes #100** — AI recommendations were failing due to stale `from app import load_config` import in `ai_provider.py`. Updated to import from `proxbalance.config_manager`.
- **Fixes #99** — Installer now prompts for an optional VLAN tag during network configuration, preventing `apt update` from hanging on tagged VLANs.

## Test plan
- [ ] Verify AI recommendations generate successfully (no import error in logs)
- [ ] Run `install.sh` and confirm VLAN prompt appears after DHCP/Static selection
- [ ] Test with blank VLAN input (should skip), valid tag (1-4094), and invalid tag (shows warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)