### PR TITLE
fix(install): resolve install-path issues #103, #104, #105

### DIFF
--- a/check-status.sh
+++ b/check-status.sh
@@ -165,29 +165,24 @@ echo -e "${BL}━━━━━━━━━━━━━━━━━━━━━━
 echo -e "${BL}Frontend Build Status${CL}"
 echo -e "${BL}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${CL}"
 
-# Check Node.js
+# Check Node.js — only needed to *rebuild* the frontend; the running site serves
+# prebuilt assets. esbuild (the bundler) requires Node 18+, so flag older versions:
+# a too-old Node is the usual reason app.js/index.html never got built (see issue #105).
 NODE_VERSION=$(pct exec "$CTID" -- node --version 2>/dev/null || echo "not installed")
 if [ "$NODE_VERSION" != "not installed" ]; then
-    echo -e "${CM} Node.js: ${GN}${NODE_VERSION}${CL}"
+    NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/^v//; s/\..*//')
+    if [ "${NODE_MAJOR:-0}" -ge 18 ] 2>/dev/null; then
+        echo -e "${CM} Node.js: ${GN}${NODE_VERSION}${CL}"
+    else
+        echo -e "${YW}⚠${CL} Node.js: ${YW}${NODE_VERSION} — too old to build the frontend (need v18+; install via NodeSource)${CL}"
+    fi
 else
-    echo -e "${CROSS} Node.js: ${RD}not installed${CL}"
+    echo -e "${CROSS} Node.js: ${RD}not installed${CL} (only required to rebuild)"
 fi
 
-# Check npm
-NPM_VERSION=$(pct exec "$CTID" -- npm --version 2>/dev/null || echo "not installed")
-if [ "$NPM_VERSION" != "not installed" ]; then
-    echo -e "${CM} npm: ${GN}v${NPM_VERSION}${CL}"
-else
-    echo -e "${CROSS} npm: ${RD}not installed${CL}"
-fi
-
-# Check Babel
-if pct exec "$CTID" -- test -d /opt/proxmox-balance-manager/node_modules/@babel/core 2>/dev/null; then
-    BABEL_VERSION=$(pct exec "$CTID" -- jq -r '.version // "unknown"' /opt/proxmox-balance-manager/node_modules/@babel/core/package.json 2>/dev/null)
-    echo -e "${CM} Babel: ${GN}v${BABEL_VERSION}${CL}"
-else
-    echo -e "${CROSS} Babel: ${RD}not installed${CL}"
-fi
+# NOTE: the frontend builds with esbuild + tailwindcss (fetched via npx) — there is no
+# Babel and no committed package.json. The real runtime health signal is the deployed
+# assets below (app.js / React / index.html in /var/www/html), not the build toolchain.
 
 # Check compiled app.js
 if pct exec "$CTID" -- test -f /var/www/html/assets/js/app.js 2>/dev/null; then

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -112,6 +112,25 @@ chmod +x *.py *.sh 2>/dev/null || true
 "
 ```
 
+#### Build and deploy the web UI
+
+**Don't skip this** — nginx serves prebuilt files from `/var/www/html/`. If you skip it the web UI is empty and you get **403 Forbidden**. (The automated installer does this for you.) Requires the Node.js 20 installed in step 2 — distro `nodejs` (e.g. Node 12 on Ubuntu) is too old for esbuild.
+
+```bash
+pct exec $CTID -- bash -c "
+cd /opt/proxmox-balance-manager
+bash build.sh                                    # Tailwind + esbuild -> assets/js/app.js, assets/css/tailwind.css
+mkdir -p /var/www/html/assets/js /var/www/html/assets/css
+cp index.html /var/www/html/index.html
+cp assets/js/app.js /var/www/html/assets/js/app.js
+cp assets/css/tailwind.css /var/www/html/assets/css/tailwind.css
+cp assets/*.svg /var/www/html/assets/ 2>/dev/null || true
+# React/ReactDOM are served locally (index.html references them under /assets/js/)
+curl -sL https://unpkg.com/react@18/umd/react.production.min.js -o /var/www/html/assets/js/react.production.min.js
+curl -sL https://unpkg.com/react-dom@18/umd/react-dom.production.min.js -o /var/www/html/assets/js/react-dom.production.min.js
+"
+```
+
 ### 4. Configure
 
 ```bash
@@ -134,12 +153,18 @@ EOF'
 On the Proxmox host:
 
 ```bash
+# Create the PAM service account first (the token belongs to this user)
+pveum user add proxbalance@pam --comment "ProxBalance service account"
+
+# Create the API token
 pvesh create /access/users/proxbalance@pam/token/proxbalance \
   --comment "ProxBalance monitoring" --privsep 0
 
-# Set permissions (both user and token need ACLs)
+# Set permissions (both user and token need ACLs).
+# NOTE: the token ID contains '!', so it MUST be single-quoted —
+# in double quotes bash treats it as history expansion ("event not found").
 pveum acl modify / --users proxbalance@pam --roles PVEVMAdmin --propagate 1
-pveum acl modify / --tokens proxbalance@pam!proxbalance --roles PVEVMAdmin --propagate 1
+pveum acl modify / --tokens 'proxbalance@pam!proxbalance' --roles PVEVMAdmin --propagate 1
 ```
 
 Copy the token secret into `config.json`.
@@ -283,14 +308,29 @@ free -h && df -h    # Check host resources
 # Check token exists
 pvesh get /access/users/proxbalance@pam/token/proxbalance
 
-# Recreate if needed
+# Recreate if needed (single-quote the token ID — the '!' is history expansion in double quotes)
 pvesh delete /access/users/proxbalance@pam/token/proxbalance
 pvesh create /access/users/proxbalance@pam/token/proxbalance --comment "ProxBalance" --privsep 0
 
 # Set permissions on both user and token
 pveum acl modify / --users proxbalance@pam --roles PVEVMAdmin
-pveum acl modify / --tokens proxbalance@pam!proxbalance --roles PVEVMAdmin
+pveum acl modify / --tokens 'proxbalance@pam!proxbalance' --roles PVEVMAdmin
 ```
+
+### 403 Forbidden (or blank page) on port 80
+
+nginx has nothing to serve — the frontend was never built/deployed to `/var/www/html/`
+(the most common cause is skipping the build step, or building with a too-old Node).
+
+```bash
+# Is the web root populated?
+pct exec $CTID -- ls -l /var/www/html/ /var/www/html/assets/js/
+# Node must be v18+ for esbuild (distro 'nodejs' on Ubuntu is too old):
+pct exec $CTID -- node --version
+```
+
+If `index.html` / `assets/js/app.js` are missing, re-run the build & deploy step
+(see "Build and deploy the web UI" above), then `systemctl reload nginx`.
 
 ### 502 Bad Gateway
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -95,7 +95,7 @@ pveum user token add proxbalance@pam proxbalance --privsep=0
 
 # Set permissions on both user and token
 pveum acl modify / --users proxbalance@pam --roles PVEVMAdmin
-pveum acl modify / --tokens proxbalance@pam!proxbalance --roles PVEVMAdmin
+pveum acl modify / --tokens 'proxbalance@pam!proxbalance' --roles PVEVMAdmin
 ```
 
 Update credentials in the web UI Settings or directly in `config.json`.
@@ -108,7 +108,7 @@ Token secrets cannot be retrieved after creation. Delete and recreate:
 pveum user token remove proxbalance@pam proxbalance
 pveum user token add proxbalance@pam proxbalance --privsep=0
 pveum acl modify / --users proxbalance@pam --roles PVEVMAdmin
-pveum acl modify / --tokens proxbalance@pam!proxbalance --roles PVEVMAdmin
+pveum acl modify / --tokens 'proxbalance@pam!proxbalance' --roles PVEVMAdmin
 ```
 
 Update the secret in ProxBalance Settings and restart the collector.

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,12 @@
 set -euo pipefail
 shopt -s inherit_errexit nullglob
 
+# With `set -euo pipefail` any unhandled non-zero command aborts the script. Without a
+# trap that abort is INVISIBLE — the installer just stops with no message and no CT
+# created (issue #103). This surfaces the failing line + command so it's actionable.
+# (Color vars are expanded when the trap fires, by which point they're defined.)
+trap 'rc=$?; echo -e "\n${RD:-}✗ install.sh aborted (exit ${rc}) at line ${LINENO}: ${BASH_COMMAND}${CL:-}\n${YW:-}  If unexpected, report this line at https://github.com/Pr0zak/ProxBalance/issues${CL:-}" >&2' ERR
+
 # ═══════════════════════════════════════════════════════════════
 # Color Definitions
 # ═══════════════════════════════════════════════════════════════
@@ -478,25 +484,33 @@ select_storage() {
 select_template() {
   subsection_header "Template Configuration"
 
-  local template_name="debian-12-standard_12.2-1_amd64.tar.zst"
-  local template_path="local:vztmpl/${template_name}"
+  # ProxBalance runs on Debian 12 OR 13 (both have a recent-enough Python; Node comes
+  # from NodeSource). Match by PREFIX, not a pinned version like "12.2-1" — that exact
+  # string disappears across PVE releases and was a cause of the silent failure (#103).
 
-  if pveam list local | grep -q "$template_name"; then
-    TEMPLATE="$template_path"
-    msg_ok "Using template: ${VALUE_COLOR}${template_name}${CL}"
+  # 1) Reuse an already-downloaded standard template (newest by version sort).
+  local existing
+  existing=$(pveam list local 2>/dev/null | awk '{print $1}' \
+    | grep -oE 'debian-1[23]-standard[^[:space:]]*\.tar\.(zst|gz|xz)' | sort -V | tail -1 || true)
+  if [ -n "$existing" ]; then
+    TEMPLATE="local:vztmpl/${existing}"
+    msg_ok "Using template: ${VALUE_COLOR}${existing}${CL}"
     return
   fi
 
-  mapfile -t TEMPLATES < <(pveam available | grep "debian-12-standard" | awk '{print $2}')
+  # 2) Otherwise list what's downloadable (Debian 12 + 13 standard, newest first).
+  mapfile -t TEMPLATES < <(pveam available 2>/dev/null | awk '{print $2}' \
+    | grep -E '^debian-1[23]-standard' | sort -V -r || true)
 
   if [ ${#TEMPLATES[@]} -eq 0 ]; then
-    msg_warn "No Debian 12 templates available"
-    echo -ne "${PROMPT_COLOR}${ARROW}${CL} Enter template path manually: "
+    msg_warn "No Debian 12/13 standard templates found via 'pveam available'"
+    msg_info "Run 'pveam update' on the host, or enter a template path manually."
+    echo -ne "${PROMPT_COLOR}${ARROW}${CL} Template path (e.g. local:vztmpl/debian-13-standard_13.0-1_amd64.tar.zst): "
     read TEMPLATE
     return
   fi
 
-  echo -e "  ${DIM_COLOR}Available Debian 12 templates:${CL}"
+  echo -e "  ${DIM_COLOR}Available Debian standard templates (newest first):${CL}"
   echo ""
   for i in "${!TEMPLATES[@]}"; do
     menu_option "$((i+1))" "${TEMPLATES[$i]}" ""
@@ -511,7 +525,7 @@ select_template() {
   if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le ${#TEMPLATES[@]} ]; then
     local selected_template="${TEMPLATES[$((choice-1))]}"
 
-    if ! pveam list local | grep -q "$selected_template"; then
+    if ! pveam list local | grep -qF "$selected_template"; then
       echo ""
       msg_info "Downloading template..."
       if pveam download local "$selected_template"; then


### PR DESCRIPTION
Resolves the three open install-path issues reported by @onlineapps-cloud.

## #104 — Manual install: token creation broken
- Add the missing `pveum user add proxbalance@pam` step before the token is created (the guide jumped straight to `pvesh create .../token/...` → *"no such user"*).
- Single-quote `'proxbalance@pam!proxbalance'` in `INSTALL.md` and `TROUBLESHOOTING.md` — unquoted, the `!` triggers bash history expansion (*"event not found"*) on copy-paste. (Thanks to the reporter for the exact diagnosis.)

## #105 — Web UI won't start after manual install (403 Forbidden)
- The manual guide never built/deployed the frontend, so nginx's `/var/www/html` stayed empty → 403. Added a **"Build and deploy the web UI"** step (build.sh + copy `index.html`/`app.js`/`tailwind.css`/React to the web root).
- Added a **403 Forbidden** troubleshooting entry.
- `check-status.sh`: removed the stale **Babel/npm** checks (the project builds with **esbuild** via npx — there is no Babel) and added a warning when **Node < 18** (esbuild needs 18+; the reporter's Ubuntu CT had Node 12, which silently failed the build).

## #103 — install.sh exits silently, no CT created (PVE 9.x)
- Added an **ERR trap** that prints the failing line + command + exit code — a `set -euo pipefail` abort was previously invisible.
- `select_template`: stopped pinning the exact `debian-12-standard_12.2-1` (gone on 9.x — now `12.12-1`, default `debian-13-standard_13.1-2`). Now matches Debian **12 or 13** standard by prefix, reuses an already-downloaded template, picks the newest, and handles an empty list gracefully. Verified against a live PVE 9.2 node.

## Test plan
- [x] `bash -n install.sh && bash -n check-status.sh`
- [x] ERR trap prints failing line/command on a simulated failure
- [x] Template detection picks `debian-13-standard_13.1-2` (reuse path) on a real 9.2 node
- [ ] Reporter re-runs the patched `install.sh` and confirms the CT is created (or pastes the now-visible error)